### PR TITLE
HAVE_AMD64_ASM flag only when TRY_COMPILE succeed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,8 @@ ELSE(DISABLE_ASM)
     IF(ASSEMBLER_AVAILABLE)
 
         TRY_COMPILE(HAVE_AMD64_ASM_COMPILE ${CMAKE_CURRENT_BINARY_DIR}/build ${CMAKE_CURRENT_SOURCE_DIR}/test/HAVE_AMD64_ASM.c)
-        ADD_DEFINITIONS(-DHAVE_AMD64_ASM=1)
         IF(HAVE_AMD64_ASM_COMPILE)
+            ADD_DEFINITIONS(-DHAVE_AMD64_ASM=1)
 
             SET(libsodium_HEADERS ${libsodium_HEADERS}
                 src/libsodium/crypto_stream/salsa20/amd64_xmm6/api.h


### PR DESCRIPTION
We run into a bug.

When using CMake under Windows (with NMake generator), ASM is not disabled but not really available.
And the flag "HAVE_AMD64_ASM" was defined but must not be.
