### PR TITLE
inline definition for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ endif(NOT DISABLE_CPM)
 
 MESSAGE("---------------- PERFORMING SYSTEM CHECKS. ----------------")
 
+# MSVC does not provide inline in C (only CXX)
+IF(MSVC)
+    ADD_DEFINITIONS("-Dinline=__inline")
+ENDIF(MSVC)
+
 #Endianess check
 INCLUDE(TestBigEndian)
 TEST_BIG_ENDIAN(BIG_ENDIAN)


### PR DESCRIPTION
`inline` is not defined in Visual Studio. It must be redefined in
`__inline`.
